### PR TITLE
DOC-8157 - Scala Named Scopes & Collections example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'scala'
+    id 'application'
 }
 
 group 'com.example'
@@ -8,11 +9,15 @@ version '1.0'
 
 sourceCompatibility = 1.8
 
+application {
+    mainClassName = project.hasProperty("mainClass") ? project.getProperty("mainClass") : "NULL"
+}
+
 repositories {
     mavenCentral()
     mavenLocal()
     maven {
-        url 'http://files.couchbase.com/maven2'
+        url 'https://files.couchbase.com/maven2'
     }
     maven {
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
@@ -31,31 +36,31 @@ sourceSets {
 }
 
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.1.5-SNAPSHOT'
-    compile group: 'com.couchbase.client', name: 'tracing-opentelemetry', version: '0.3.4'
-    compile group: 'com.couchbase.client', name: 'metrics-opentelemetry', version: '0.1.4'
-    compile group: 'com.couchbase.client', name: 'metrics-micrometer', version: '0.1.4'
+    implementation group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.1.5-SNAPSHOT'
+    implementation group: 'com.couchbase.client', name: 'tracing-opentelemetry', version: '0.3.4'
+    implementation group: 'com.couchbase.client', name: 'metrics-opentelemetry', version: '0.1.4'
+    implementation group: 'com.couchbase.client', name: 'metrics-micrometer', version: '0.1.4'
 
-    compile "org.scalatest:scalatest_2.12:3.1.1"
+    implementation "org.scalatest:scalatest_2.12:3.1.1"
 
-    compile group: 'org.msgpack', name: 'msgpack-scala_2.12', version: '0.8.13'
-    compile 'io.spray:spray-json_2.12:1.3.4'
-    compile 'io.circe:circe-core_2.12:0.10.0'
-    compile 'io.circe:circe-generic_2.12:0.10.0'
-    compile 'io.circe:circe-parser_2.12:0.10.0'
-    compile 'org.scalamacros:paradise_2.12.7:2.1.1'
-    compile 'com.lihaoyi:upickle_2.12:0.7.1'
-    compile 'com.typesafe.play:play-json_2.12:2.6.7'
-    compile 'org.json4s:json4s-native_2.12:3.6.4'
-    compile 'org.json4s:json4s-jackson_2.12:3.6.4'
-    compile 'org.typelevel:jawn-ast_2.12:0.14.0'
+    implementation group: 'org.msgpack', name: 'msgpack-scala_2.12', version: '0.8.13'
+    implementation 'io.spray:spray-json_2.12:1.3.4'
+    implementation 'io.circe:circe-core_2.12:0.10.0'
+    implementation 'io.circe:circe-generic_2.12:0.10.0'
+    implementation 'io.circe:circe-parser_2.12:0.10.0'
+    implementation 'org.scalamacros:paradise_2.12.7:2.1.1'
+    implementation 'com.lihaoyi:upickle_2.12:0.7.1'
+    implementation 'com.typesafe.play:play-json_2.12:2.6.7'
+    implementation 'org.json4s:json4s-native_2.12:3.6.4'
+    implementation 'org.json4s:json4s-jackson_2.12:3.6.4'
+    implementation 'org.typelevel:jawn-ast_2.12:0.14.0'
 
-    compile 'io.opentelemetry:opentelemetry-sdk:1.1.0'
-    compile 'io.opentelemetry:opentelemetry-exporter-zipkin:1.1.0'
-    compile 'io.opentelemetry:opentelemetry-exporter-otlp:1.1.0'
-    compile 'io.grpc:grpc-netty:1.35.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk:1.1.0'
+    implementation 'io.opentelemetry:opentelemetry-exporter-zipkin:1.1.0'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp:1.1.0'
+    implementation 'io.grpc:grpc-netty:1.35.0'
     runtimeOnly group: 'io.opentelemetry', name: 'opentelemetry-api-metrics', version: '1.1.0-alpha'
     implementation group: 'io.opentelemetry', name: 'opentelemetry-sdk-metrics', version: '1.1.0-alpha'
-    compile 'io.opentelemetry:opentelemetry-exporter-prometheus:1.1.0-alpha'
-    compile 'io.prometheus:simpleclient_httpserver:0.9.0'
+    implementation 'io.opentelemetry:opentelemetry-exporter-prometheus:1.1.0-alpha'
+    implementation 'io.prometheus:simpleclient_httpserver:0.9.0'
 }

--- a/modules/howtos/examples/KvOperations.scala
+++ b/modules/howtos/examples/KvOperations.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 import com.couchbase.client.core.error._
 import com.couchbase.client.scala._
 import com.couchbase.client.scala.durability._
@@ -24,368 +24,428 @@ import com.couchbase.client.scala.kv.{GetOptions, InsertOptions, MutationResult,
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-// #end::imports[]
+// end::imports[]
 
-// #tag::cc-create[]
+// tag::cc-create[]
 case class Address(line1: String)
 case class User(name: String, age: Int, addresses: Seq[Address])
-// #end::cc-create[]
+// end::cc-create[]
 
-// #tag::cc-codec[]
+// tag::cc-codec[]
 object User {
   implicit val codec: Codec[User] = Codec.codec[User]
 }
-// #end::cc-codec[]
+// end::cc-codec[]
 
 object KvOperations {
   def main(args: Array[String]) {
 
-    def json1() {
+    // tag::cluster[]
+    val cluster = Cluster.connect("localhost", "Administrator", "password").get
+    // end::cluster[]
 
-      // User("Eric Wimp", 9, Seq(Address("29 Acacia Road")))
-// #tag::json1[]
-      val json = JsonObject(
-        "name" -> "Eric Wimp",
-        "age" -> 9,
-        "addresses" -> JsonArray(JsonObject("address" -> "29 Acacia Road"))
-      )
+    // tag::resources[]
+    val bucket = cluster.bucket("travel-sample")
+    val scope = bucket.scope("_default")
+    val collection = scope.collection("_default")
+    // end::resources[]
 
-      val str = json.toString()
-// """{"name":"Eric Wimp","age":9,"addresses":[{"address","29 Acacia Road"}]}"""
-// #end::json1[]
-
-// #tag::json-mutable[]
-      val obj = JsonObject.create.put("name", "Eric Wimp")
-      obj.put("age", 9)
-      val arr = JsonArray.create
-      arr.add(JsonObject("address" -> "29 Acacia Road"))
-      obj.put("addresses", arr)
-// #end::json-mutable[]
-
-// #tag::json2[]
-      json.str("name") // "Eric Wimp"
-      json.arr("addresses").obj(0).str("address") // "29 Acacia Road"
-// #end::json2[]
-
-      // #tag::json3[]
-      json.dyn.name.str // "Eric Wimp"
-      json.dyn.addresses(0).address.str // "29 Acacia Road"
-// #end::json3[]
-
-// #tag::json4[]
-      val safe: JsonObjectSafe = json.safe
-
-      val r: Try[String] = safe.str("name")
-
-      r match {
-        case Success(name) => println(s"Their name is $name")
-        case Failure(err)  => println(s"Could not find field 'name': $err")
-      }
-// #end::json4[]
-    }
-
-// #tag::cluster[]
-    val cluster = Cluster.connect("localhost", "username", "password").get
-// #end::cluster[]
-
-// #tag::resources[]
-    val bucket = cluster.bucket("bucket-name")
-    val scope = bucket.scope("scope-name")
-    val collection = scope.collection("collection-name")
-// #end::resources[]
-
-// #tag::apis[]
+    // tag::apis[]
     val asyncApi: AsyncCollection = collection.async
     val reactiveApi: ReactiveCollection = collection.reactive
-// #end::apis[]
+    // end::apis[]
 
-// #tag::upsert[]
+    json1
+    upsert(collection)
+    namedCollectionUpsert(bucket)
+    insert(collection)
+    getSimple(collection)
+    get(collection)
+    getFor(collection)
+    getMap(collection)
+    replace(collection)
+    replaceRetry(collection)
+    remove(collection)
+    durability(collection)
+    expiryInsert(collection)
+    expiryGet(collection)
+    expiryTouch(collection)
+    counterIncrement(collection)
+    caseClass(collection)
+  }
+  
+  def json1() {
+    println("[json1] - Example\n")
+    // User("Eric Wimp", 9, Seq(Address("29 Acacia Road")))
+    // tag::json1[]
+    val json = JsonObject(
+      "name" -> "Eric Wimp",
+      "age" -> 9,
+      "addresses" -> JsonArray(JsonObject("address" -> "29 Acacia Road"))
+    )
+
+    val str = json.toString()
+    // """{"name":"Eric Wimp","age":9,"addresses":[{"address","29 Acacia Road"}]}"""
+    // end::json1[]
+
+    println("[json-mutable] - Example\n")
+    // tag::json-mutable[]
+    val obj = JsonObject.create.put("name", "Eric Wimp")
+    obj.put("age", 9)
+    val arr = JsonArray.create
+    arr.add(JsonObject("address" -> "29 Acacia Road"))
+    obj.put("addresses", arr)
+    // end::json-mutable[]
+
+    println("[json2] - Example\n")
+    // tag::json2[]
+    json.str("name") // "Eric Wimp"
+    json.arr("addresses").obj(0).str("address") // "29 Acacia Road"
+    // end::json2[]
+    
+    println("[json3] Example\n")
+    // tag::json3[]
+    json.dyn.name.str // "Eric Wimp"
+    json.dyn.addresses(0).address.str // "29 Acacia Road"
+    // end::json3[]
+
+    println("[json4] - Example\n")
+    // tag::json4[]
+    val safe: JsonObjectSafe = json.safe
+
+    val r: Try[String] = safe.str("name")
+
+    r match {
+      case Success(name) => println(s"Their name is $name")
+      case Failure(err)  => println(s"Could not find field 'name': $err")
+    }
+    // end::json4[]
+  }
+
+  def upsert(collection:Collection) {
+    println("\n[upsert] - Example\n")
+    // tag::upsert[]
     val json = JsonObject("foo" -> "bar", "baz" -> "qux")
 
     collection.upsert("document-key", json) match {
-      case Success(result)    =>
+      case Success(result)    => println("Document upsert successful")
       case Failure(exception) => println("Error: " + exception)
     }
-// #end::upsert[]
+    // end::upsert[]
+  }
 
-    def insert() {
-// #tag::insert[]
-      collection.insert("document-key", json) match {
-        case Success(result) =>
-        case Failure(err: DocumentExistsException) =>
-          println("The document already exists")
-        case Failure(err) => println("Error: " + err)
-      }
-// #end::insert[]
+  def namedCollectionUpsert(bucket:Bucket) {
+    println("\n[named-collection-upsert] - Example\n")
+    // tag::named-collection-upsert[]
+    val agentScope = bucket.scope("tenant_agent_00")
+    val usersCollection = agentScope.collection("users")
+    val json = JsonObject("name" -> "John Doe", "preferred_email" -> "johndoe111@test123.test")
+
+    usersCollection.upsert("user-key", json) match {
+      case Success(result)    => println("Document upsert successful")
+      case Failure(exception) => println("Error: " + exception)
     }
+    // end::named-collection-upsert[]
+  }
 
-// #tag::get-simple[]
+  def insert(collection:Collection) {
+    println("\n[insert] - Example\n")
+    // tag::insert[]
+    val json = JsonObject("foo" -> "bar", "baz" -> "qux")
+
+    collection.insert("document-key2", json) match {
+      case Success(result) => println("Document inserted successfully")
+      case Failure(err: DocumentExistsException) =>
+        println("The document already exists")
+      case Failure(err) => println("Error: " + err)
+    }
+    // end::insert[]
+  }
+
+  def getSimple(collection:Collection) {
+    println("\n[get-simple] - Example\n")
+    // tag::get-simple[]
     collection.get("document-key") match {
       case Success(result) => println("Document fetched successfully")
       case Failure(err)    => println("Error getting document: " + err)
     }
-// #end::get-simple[]
+    // end::get-simple[]
+  }
 
-    def get() {
-// #tag::get[]
-// Create some initial JSON
-      val json = JsonObject("status" -> "awesome!")
-
-// Insert it
-      collection.insert("document-key", json) match {
-        case Success(result) =>
-        case Failure(err)    => println("Error: " + err)
-      }
-
-// Get it back
-      collection.get("document-key") match {
-        case Success(result) =>
-          // Convert the content to a JsonObjectSafe
-          result.contentAs[JsonObjectSafe] match {
-            case Success(json) =>
-              // Pull out the JSON's status field, if it exists
-              json.str("status") match {
-                case Success(status) => println(s"Couchbase is $status")
-                case _               => println("Field 'status' did not exist")
-              }
-            case Failure(err) => println("Error decoding result: " + err)
-          }
-        case Failure(err) => println("Error getting document: " + err)
-      }
-// #end::get[]
+  def get(collection:Collection) {
+    println("\n[get] - Example\n")
+    // tag::get[]
+    // Create some initial JSON
+    val json = JsonObject("status" -> "awesome!")
+    
+    // Insert it
+    collection.insert("document-key3", json) match {
+      case Success(result) => println("Document inserted successfully")
+      case Failure(err)    => println("Error: " + err)
     }
-
-    def getFor() {
-// #tag::get-for[]
-      val r: Try[String] = for {
-        result <- collection.get("document-key")
-        json <- result.contentAs[JsonObjectSafe]
-        status <- json.str("status")
-      } yield status
-
-      r match {
-        case Success(status) => println(s"Couchbase is $status")
-        case Failure(err)    => println("Error: " + err)
-      }
-// #end::get-for[]
-    }
-
-    def getMap() {
-// #tag::get-map[]
-      val r: Try[String] = collection
-        .get("document-key")
-        .flatMap(_.contentAs[JsonObjectSafe])
-        .flatMap(_.str("status"))
-
-      r match {
-        case Success(status) => println(s"Couchbase is $status")
-        case Failure(err)    => println("Error: " + err)
-      }
-// #end::get-map[]
-    }
-
-    def replace() {
-// #tag::replace[]
-      val initial = JsonObject("status" -> "great")
-
-      val r: Try[MutationResult] = for {
-        // Insert a document.  Don't care about the exact details of the result, just
-        // whether it was successful, so store result in _
-        _ <- collection.insert("document-key", initial)
-
-        // Get the document back
-        doc <- collection.get("document-key")
-
-        // Extract the content as a JsonObjectSafe
-        json <- doc.contentAs[JsonObjectSafe]
-
-        // Modify the content (JsonObjectSafe is mutable)
-        _ <- json.put("status", "awesome!")
-
-        // Replace the document with the updated content, and the document's CAS value
-        // (which we'll cover in a moment)
-        result <- collection.replace("document-key", json, cas = doc.cas)
-      } yield result
-
-      r match {
-        case Success(result) =>
-        case Failure(err: CasMismatchException) =>
-          println(
-            "Could not write as another agent has concurrently modified the document"
-          )
-        case Failure(err) => println("Error: " + err)
-      }
-// #end::replace[]
-    }
-
-    def replaceRetry() {
-// #tag::replace-retry[]
-      val initial = JsonObject("status" -> "great")
-
-      // Insert some initial data
-      collection.insert("document-key", json) match {
-        case Success(result) =>
-          // This is the get-and-replace we want to do, as a lambda
-          val op = () =>
-            for {
-              doc <- collection.get("document-key")
-              json <- doc.contentAs[JsonObjectSafe]
-              _ <- json.put("status", "awesome!")
-              result <- collection.replace("document-key", json, cas = doc.cas)
-            } yield result
-
-          // Send our lambda to retryOnCASMismatch to take care of retrying it
-          // For space reasons, error-handling of r is left out
-          val r: Try[MutationResult] = retryOnCASMismatch(op)
-
-        case Failure(err) => println("Error: " + err)
-      }
-
-      // Try the provided operation, retrying on CasMismatchException
-      def retryOnCASMismatch(
-        op: () => Try[MutationResult]
-      ): Try[MutationResult] = {
-        // Perform the operation
-        val result = op()
-
-        result match {
-          // Retry on any CasMismatchException errors
-          case Failure(err: CasMismatchException) =>
-            retryOnCASMismatch(op)
-
-          // If Success or any other Failure, return it
-          case _ => result
+    
+    // Get it back
+    collection.get("document-key3") match {
+      case Success(result) =>
+        // Convert the content to a JsonObjectSafe
+        result.contentAs[JsonObjectSafe] match {
+          case Success(json) =>
+            // Pull out the JSON's status field, if it exists
+            json.str("status") match {
+              case Success(status) => println(s"Couchbase is $status")
+              case _               => println("Field 'status' did not exist")
+            }
+          case Failure(err) => println("Error decoding result: " + err)
         }
-      }
-// #end::replace-retry[]
+      case Failure(err) => println("Error getting document: " + err)
+    }
+    // end::get[]
+  }
+
+  def getFor(collection:Collection) {
+    println("\n[get-for] - Example\n")
+    // tag::get-for[]
+    val r: Try[String] = for {
+      result <- collection.get("document-key3")
+      json <- result.contentAs[JsonObjectSafe]
+      status <- json.str("status")
+    } yield status
+
+    r match {
+      case Success(status) => println(s"Couchbase is $status")
+      case Failure(err)    => println("Error: " + err)
+    }
+    // end::get-for[]
+  }
+
+  def getMap(collection:Collection) {
+    println("\n[get-map] - Example\n")
+    // tag::get-map[]
+    val r: Try[String] = collection
+      .get("document-key3")
+      .flatMap(_.contentAs[JsonObjectSafe])
+      .flatMap(_.str("status"))
+
+    r match {
+      case Success(status) => println(s"Couchbase is $status")
+      case Failure(err)    => println("Error: " + err)
+    }
+    // end::get-map[]
+  }
+
+  def replace(collection:Collection) {
+    println("\n[replace] - Example\n")
+    // tag::replace[]
+    val initial = JsonObject("status" -> "great")
+
+    val r: Try[MutationResult] = for {
+      // Insert a document.  Don't care about the exact details of the result, just
+      // whether it was successful, so store result in _
+      _ <- collection.insert("document-key4", initial)
+
+      // Get the document back
+      doc <- collection.get("document-key4")
+
+      // Extract the content as a JsonObjectSafe
+      json <- doc.contentAs[JsonObjectSafe]
+
+      // Modify the content (JsonObjectSafe is mutable)
+      _ <- json.put("status", "awesome!")
+
+      // Replace the document with the updated content, and the document's CAS value
+      // (which we'll cover in a moment)
+      result <- collection.replace("document-key4", json, cas = doc.cas)
+    } yield result
+
+    r match {
+      case Success(result) => println("Document replaced successfully")
+      case Failure(err: CasMismatchException) =>
+        println(
+          "Could not write as another agent has concurrently modified the document"
+        )
+      case Failure(err) => println("Error: " + err)
+    }
+    // end::replace[]
+  }
+
+  def replaceRetry(collection:Collection) {
+    println("\n[replace-retry] - Example\n")
+    // tag::replace-retry[]
+    val initial = JsonObject("status" -> "great")
+
+    // Insert some initial data
+    collection.insert("document-key5", initial) match {
+      case Success(result) =>
+        // This is the get-and-replace we want to do, as a lambda
+        val op = () =>
+          for {
+            doc <- collection.get("document-key5")
+            json <- doc.contentAs[JsonObjectSafe]
+            _ <- json.put("status", "awesome!")
+            result <- collection.replace("document-key5", json, cas = doc.cas)
+          } yield result
+
+        // Send our lambda to retryOnCASMismatch to take care of retrying it
+        // For space reasons, error-handling of r is left out
+        val r: Try[MutationResult] = retryOnCASMismatch(op)
+
+      case Failure(err) => println("Error: " + err)
     }
 
-    def remove() {
-// #tag::remove[]
-      collection.remove("document-key") match {
-        case Success(result) =>
-        case Failure(err: DocumentNotFoundException) =>
-          println("The document does not exist")
-        case Failure(err) => println("Error: " + err)
+    // Try the provided operation, retrying on CasMismatchException
+    def retryOnCASMismatch(
+      op: () => Try[MutationResult]
+    ): Try[MutationResult] = {
+      // Perform the operation
+      val result = op()
+
+      result match {
+        // Retry on any CasMismatchException errors
+        case Failure(err: CasMismatchException) =>
+          retryOnCASMismatch(op)
+
+        // If Success or any other Failure, return it
+        case _ => result
       }
-// #end::remove[]
     }
+    // end::replace-retry[]
+  }
 
-    def durability() {
-// #tag::durability[]
-      collection.remove("document-key", durability = Durability.Majority) match {
-        case Success(result) =>
-        // The mutation is available in-memory on at least a majority of replicas
-        case Failure(err: DocumentNotFoundException) =>
-          println("The document does not exist")
-        case Failure(err) => println("Error: " + err)
-      }
-// #end::durability[]
-
-// #tag::durability-observed[]
-      collection.remove(
-        "document-key",
-        durability = Durability.ClientVerified(ReplicateTo.Two, PersistTo.None)
-      ) match {
-        case Success(result) =>
-        // The mutation is available in-memory on at least two replicas
-        case Failure(err: DocumentNotFoundException) =>
-          println("The document does not exist")
-        case Failure(err) => println("Error: " + err)
-      }
-// #end::durability-observed[]
+  def remove(collection:Collection) {
+    println("\n[remove] - Example\n")
+    // tag::remove[]
+    collection.remove("document-key") match {
+      case Success(result) => println("Document removed successfully")
+      case Failure(err: DocumentNotFoundException) =>
+        println("The document does not exist")
+      case Failure(err) => println("Error: " + err)
     }
+    // end::remove[]
+  }
 
-    def expiryInsert() {
-// #tag::expiry-insert[]
-      collection.insert("document-key", json, InsertOptions().expiry(2.hours)) match {
-        case Success(result) =>
-        case Failure(err)    => println("Error: " + err)
-      }
-// #end::expiry-insert[]
+  def durability(collection:Collection) {
+    println("\n[durability] - Example\n")
+    // tag::durability[]
+    collection.remove("document-key2", durability = Durability.Majority) match {
+      case Success(result) => println("Document removed successfully")
+      // The mutation is available in-memory on at least a majority of replicas
+      case Failure(err: DocumentNotFoundException) =>
+        println("The document does not exist")
+      case Failure(err) => println("Error: " + err)
     }
+    // end::durability[]
 
-    def expiryGet() {
-// #tag::expiry-get[]
-      collection.get("document-key", GetOptions().withExpiry(true)) match {
-        case Success(result) =>
-          result.expiry match {
-            case Some(expiry) => print(s"Got expiry: $expiry")
-            case _            => println("Err: no expiration field")
-          }
-
-        case Failure(err) => println("Error getting document: " + err)
-      }
-// #end::expiry-get[]
+    println("\n[durability-observed] - Example\n")
+    // tag::durability-observed[]
+    collection.remove(
+      "document-key3",
+      durability = Durability.ClientVerified(ReplicateTo.Two, PersistTo.None)
+    ) match {
+      case Success(result) => println("Document successfully removed")
+      // The mutation is available in-memory on at least two replicas
+      case Failure(err: DocumentNotFoundException) =>
+        println("The document does not exist")
+      case Failure(err) => println("Error: " + err)
     }
+    // end::durability-observed[]
+  }
 
-    def expiryReplace() {
-// #tag::expiry-replace[]
-      val r: Try[MutationResult] = for {
-        doc <- collection.get("document-key", GetOptions().withExpiry(true))
-        expiry <- Try(doc.expiry.get)
-        // ^^ doc.expiration is an Option, but we can't mix Try and
-        // Option inside the same for-comprehension, so convert here
-        json <- doc.contentAs[JsonObjectSafe]
-        _ <- json.put("foo", "bar")
-        result <- collection.replace("document-key", json, ReplaceOptions().expiry(expiry))
-      } yield result
+  def expiryInsert(collection:Collection) {
+    println("\n[expiry-insert] - Example\n")
+    // tag::expiry-insert[]
+    val json = JsonObject("foo" -> "bar", "baz" -> "qux")
 
-      r match {
-        case Success(status) =>
-        case Failure(err)    => println("Error: " + err)
-      }
-// #end::expiry-replace[]
+    collection.insert("document-key", json, InsertOptions().expiry(2.hours)) match {
+      case Success(result) => println("Document with expiry inserted successfully")
+      case Failure(err)    => println("Error: " + err)
     }
+    // end::expiry-insert[]
+  }
 
-    def expiryTouch() {
-// #tag::expiry-touch[]
-      collection.getAndTouch("document-key", expiry = 4.hours) match {
-        case Success(result) =>
-        case Failure(err)    => println("Error: " + err)
-      }
-// #end::expiry-touch[]
+  def expiryGet(collection:Collection) {
+    println("\n[expiry-get] - Example\n")
+    // tag::expiry-get[]
+    collection.get("document-key", GetOptions().withExpiry(true)) match {
+      case Success(result) =>
+        result.expiry match {
+          case Some(expiry) => println(s"Got expiry: $expiry")
+          case _            => println("Err: no expiration field")
+        }
+
+      case Failure(err) => println("Error getting document: " + err)
     }
+    // end::expiry-get[]
+  }
 
-    def counterIncrement() {
-// #tag::counter-increment[]
-// Increase a counter by 1, seeding it at an initial value of 0 if it does not exist
-      collection.binary.increment("document-key", delta = 1, initial = Some(0)) match {
-        case Success(result) =>
-          println(s"Counter now: ${result.content}")
-        case Failure(err) => println("Error: " + err)
-      }
+  def expiryReplace(collection:Collection) {
+    println("\n[expiry-replace] - Example\n")
+    // tag::expiry-replace[]
+    val r: Try[MutationResult] = for {
+      doc <- collection.get("document-key", GetOptions().withExpiry(true))
+      expiry <- Try(doc.expiry.get)
+      // ^^ doc.expiration is an Option, but we can't mix Try and
+      // Option inside the same for-comprehension, so convert here
+      json <- doc.contentAs[JsonObjectSafe]
+      _ <- json.put("foo", "bar")
+      result <- collection.replace("document-key", json, ReplaceOptions().expiry(expiry))
+    } yield result
 
-// Decrease a counter by 1, seeding it at an initial value of 10 if it does not exist
-      collection.binary.decrement("document-key", delta = 1, initial = Some(10)) match {
-        case Success(result) =>
-          println(s"Counter now: ${result.content}")
-        case Failure(err) => println("Error: " + err)
-      }
-// #end::counter-increment[]
+    r match {
+      case Success(status) => println("Document with expiry replaced successfully")
+      case Failure(err)    => println("Error: " + err)
     }
+    // end::expiry-replace[]
+  }
 
-    def caseClass() {
-
-// #tag::cc-fails[]
-      val user = User("Eric Wimp", 9, Seq(Address("29 Acacia Road")))
-
-// Will fail to compile
-      collection.insert("eric-wimp", user)
-// #end::cc-fails[]
-
-// #tag::cc-get[]
-      val r: Try[User] = for {
-        doc <- collection.get("document-key")
-        user <- doc.contentAs[User]
-      } yield user
-
-      r match {
-        case Success(user: User) => println(s"User: ${user}")
-        case Failure(err)        => println("Error: " + err)
-      }
-// #end::cc-get[]
-
+  def expiryTouch(collection:Collection) {
+    println("\n[expiry-touch] - Example\n")
+    // tag::expiry-touch[]
+    collection.getAndTouch("document-key", expiry = 4.hours) match {
+      case Success(result) => println("Document fetched and updated with expiry")
+      case Failure(err)    => println("Error: " + err)
     }
+    // end::expiry-touch[]
+  }
+
+  def counterIncrement(collection:Collection) {
+    println("\n[counter-increment] - Example\n")
+    // tag::counter-increment[]
+    // Increase a counter by 1, seeding it at an initial value of 1 if it does not exist
+    collection.binary.increment("document-key6", delta = 1, initial = Some(1)) match {
+      case Success(result) =>
+        println(s"Counter now: ${result.content}")
+      case Failure(err) => println("Error: " + err)
+    }
+    
+    // Decrease a counter by 1, seeding it at an initial value of 10 if it does not exist
+    collection.binary.decrement("document-key6", delta = 1, initial = Some(10)) match {
+      case Success(result) =>
+        println(s"Counter now: ${result.content}")
+      case Failure(err) => println("Error: " + err)
+    }
+    // end::counter-increment[]
+  }
+
+  def caseClass(collection:Collection) {
+    println("\n[cc-fails] - Example\n")
+    // tag::cc-fails[]
+    val user = User("Eric Wimp", 9, Seq(Address("29 Acacia Road")))
+
+    // Will fail to compile
+    collection.insert("eric-wimp", user) 
+    // end::cc-fails[]
+
+    println("\n[cc-get] - Example\n")
+    // tag::cc-get[]
+    val r: Try[User] = for {
+      doc <- collection.get("eric-wimp")
+      user <- doc.contentAs[User]
+    } yield user
+
+    r match {
+      case Success(user: User) => println(s"User: ${user}")
+      case Failure(err)        => println("Error: " + err)
+    }
+    // end::cc-get[]
   }
 }

--- a/modules/howtos/examples/KvOperations.scala
+++ b/modules/howtos/examples/KvOperations.scala
@@ -55,7 +55,7 @@ object KvOperations {
     val reactiveApi: ReactiveCollection = collection.reactive
     // end::apis[]
 
-    json1
+    json1()
     upsert(collection)
     namedCollectionUpsert(bucket)
     insert(collection)

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -304,6 +304,21 @@ include::example$KvOperations.scala[indent=0,tag=counter-increment]
 
 Note that a counter cannot be below 0.
 
+== Scoped KV Operations
+
+It is possible to perform scoped key-value operations on named xref:7.0@server:learn:data/scopes-and-collections.adoc[`Collections`] _with the beta version of the next Couchbase Server release, 7.0β_.
+See the https://docs.couchbase.com/sdk-api/couchbase-scala-client/com/couchbase/client/scala/Collection.html[API docs] for more information.
+
+CAUTION: This feature is marked xref:project-docs:compatibility.adoc#interface-stability[_Uncommitted_].
+Expect a promotion to _Committed_ API in a future minor release.
+
+Here is an example showing an upsert in the `users` collection, which lives in the `travel-sample.tenant_agent_00` keyspace:
+
+[source,scala]
+----
+include::example$KvOperations.scala[indent=0,tag=named-collection-upsert]
+----
+
 == Additional Resources
 
 Working on just a specific path within a JSON document will reduce network bandwidth requirements - see the xref:subdocument-operations.adoc[Sub-Document] pages.


### PR DESCRIPTION
This adds a named scopes and collections example in kv-operations.adoc.
I've also tried to make it so objects with a main function are runnable with Gradle, since that's what we seem to be using.

For example:
```
gradle clean build -PmainClass=KvOperations run
```
Please let me know if there is a better way to do this as I am not too familiar with Scala and haven't used Gradle in ages! 😓 
Also it seems in the latest version of Gradle (7.0) the `compile()` function has been deprecated in favour of `implementation()` so I've made the necessary changes. Though there's also `compileOnly()` but not sure which to use, please advise (happy to switch to that).