### PR TITLE
Update encrypting-using-sdk.adoc

### DIFF
--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -11,4 +11,4 @@ The Field Level Encryption library enables encryption and decryption of JSON fie
 Client-side implementation of Field Level Encryption is available in the previous versions of some of the other SDKs.
 It will be enabled in a future release of the third generation SDK.
 
-Field Level Encryption is available in the xref:3.1@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK], the xref:2.2@go-sdk:howtos:encrypting-using-sdk.adoc[Go SDK] and a _developer preview_ in the xref:3.1@dotnet-sdk:howtos:encrypting-using-sdk.adoc[.NET SDK].
+Field Level Encryption is available in the xref:3.1@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK], the xref:2.2@go-sdk:howtos:encrypting-using-sdk.adoc[Go SDK], and a _developer preview_ in the xref:3.1@dotnet-sdk:howtos:encrypting-using-sdk.adoc[.NET SDK].

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -11,4 +11,4 @@ The Field Level Encryption library enables encryption and decryption of JSON fie
 Client-side implementation of Field Level Encryption is available in the previous versions of some of the other SDKs.
 It will be enabled in a future release of the third generation SDK.
 
-Field Level Encryption is available in the xref:3.0@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK], the xref:2.2@go-sdk:howtos:encrypting-using-sdk.adoc[Go SDK] and a _developer preview_ in the xref:3.1@dotnet-sdk:howtos:encrypting-using-sdk.adoc[.NET SDK].
+Field Level Encryption is available in the xref:3.1@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK], the xref:2.2@go-sdk:howtos:encrypting-using-sdk.adoc[Go SDK] and a _developer preview_ in the xref:3.1@dotnet-sdk:howtos:encrypting-using-sdk.adoc[.NET SDK].

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -11,4 +11,4 @@ The Field Level Encryption library enables encryption and decryption of JSON fie
 Client-side implementation of Field Level Encryption is available in the previous versions of some of the other SDKs.
 It will be enabled in a future release of the third generation SDK.
 
-A _Developer Preview_ is available in the xref:3.0@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK].
+Field Level Encryption is available in the xref:3.0@java-sdk:howtos:encrypting-using-sdk.adoc[Java SDK], the xref:2.2@go-sdk:howtos:encrypting-using-sdk.adoc[Go SDK] and a _developer preview_ in the xref:3.1@dotnet-sdk:howtos:encrypting-using-sdk.adoc[.NET SDK].


### PR DESCRIPTION
Noted that these old partials were linking only to Java FLE.  I didn't check links and this may require further edits.  Like should it link to 3.1 for Java?