### PR TITLE
Run descriptionizer on all adoc files

### DIFF
--- a/modules/concept-docs/pages/analytics-for-sdk-users.adoc
+++ b/modules/concept-docs/pages/analytics-for-sdk-users.adoc
@@ -1,4 +1,5 @@
 = Analytics
+:description: Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
 :nav-title: Analytics for SDK Users
 :page-topic-type: concept
 :page-aliases: analytics,
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
+{description}
 
 
 For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operation.

--- a/modules/concept-docs/pages/buckets-and-clusters.adoc
+++ b/modules/concept-docs/pages/buckets-and-clusters.adoc
@@ -1,4 +1,5 @@
 = Buckets and Clusters
+:description: The Couchbase Scala SDK provides an API for managing a Couchbase cluster programmatically.
 :navtitle: Buckets & Clusters
 :page-topic-type: concept
 :page-aliases: managing-clusters
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The Couchbase Scala SDK provides an API for managing a Couchbase cluster programmatically.
+{description}
 
 include::{version-server}@sdk:shared:partial$clusters-buckets.adoc[tag=management]
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -1,10 +1,11 @@
 = Compression
+:description: In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 :page-aliases:../../ROOT/pages/compression-intro.adoc
 
 [abstract]
-In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
+{description}
 
 // 2.7 docs to update <---------------------
 // needs moving to sdk-common

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -1,11 +1,11 @@
 = Compression
-:description: In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
+:description: Data compression to reduce traffic costs from app to Server. 
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 :page-aliases:../../ROOT/pages/compression-intro.adoc
 
 [abstract]
-{description}
+In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
 
 // 2.7 docs to update <---------------------
 // needs moving to sdk-common

--- a/modules/concept-docs/pages/concepts.adoc
+++ b/modules/concept-docs/pages/concepts.adoc
@@ -1,9 +1,10 @@
 = Concepts
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: Concepts
 :page-topic-type: landing-page
 :lang: Scala
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 include::{version-server}@sdk:shared:partial$concepts.adoc[tag=concepts]
 

--- a/modules/concept-docs/pages/data-model.adoc
+++ b/modules/concept-docs/pages/data-model.adoc
@@ -1,4 +1,5 @@
 = The Data Model
+:description: Couchbase's use of JSON as a storage format allows powerful search and query over documents.
 :nav-title: Data Model
 :page-topic-type: concept
 :page-aliases: ROOT:core-operations, ROOT:datastructures
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Couchbase's use of JSON as a storage format allows powerful search and query over documents.
+{description}
 Several data structures are supported by the SDK, including map, list, queue, and set.
 
 include::{version-server}@sdk:shared:partial$data-model.adoc[tag=intro]

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -1,4 +1,5 @@
 = Document
+:description: Couchbase supports CRUD operations, various data structures, and binary documents.
 :nav-title: Documents & Doc Ops
 :page-topic-type: concept
 //:page-aliases: ROOT:core-operations
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Couchbase supports CRUD operations, various data structures, and binary documents.
+{description}
 
 Although query and path-based (Sub-Document) services are available, the simplicity of the document-based kv interface is the fastest way to perform operations involving single documents.
 

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -1,11 +1,12 @@
 = Durability & Failure
+:description: Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
 :page-topic-type: concept
 :page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
+{description}
 Even the most reliable software and hardware might fail at some point, and along with the failures, introduce a chance of data loss.
 Couchbase’s durability features include Synchronous Replication, and the possibility to use distributed, multi-document ACID transactions.
 It is the responsibility of the development team and the software architect to evaluate the best choice for each use case.

--- a/modules/concept-docs/pages/encryption.adoc
+++ b/modules/concept-docs/pages/encryption.adoc
@@ -1,10 +1,11 @@
 = Field Level Encryption
+:description: Fields within a document can be securely encrypted by the SDK, to support FIPS-140-2 compliance.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 :page-aliases: ROOT:encrypting-using-sdk,ROOT:encryption
 
 [abstract]
-Fields within a document can be securely encrypted by the SDK, to support FIPS-140-2 compliance.
+{description}
 
 
 Client-side implementation of Field Level Encryption is available in the xref:2.7@java-sdk::encryption.adoc[previous (2.0 API) version of the other SDKs].

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -1,5 +1,5 @@
 = Errors, Exceptions, and Diagnostics
-:description: When the unexpected happens, take a step-by-step approach. .
+:description: When the unexpected happens, take a step-by-step approach.
 :nav-title: Errors & Diagnostics
 :page-topic-type: concept
 :page-aliases:

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -1,4 +1,5 @@
 = Errors, Exceptions, and Diagnostics
+:description: When the unexpected happens, take a step-by-step approach. .
 :nav-title: Errors & Diagnostics
 :page-topic-type: concept
 :page-aliases:
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-When the unexpected happens, take a step-by-step approach. .
+{description}
 
 
 == General Approach to Scala Exceptions

--- a/modules/concept-docs/pages/health-check.adoc
+++ b/modules/concept-docs/pages/health-check.adoc
@@ -1,4 +1,5 @@
 = Health Check
+:description: Health Check provides ping() and diagnostics() tests for the health of the network and the cluster.
 :nav-title: Health Check
 :page-topic-type: concept
 :page-aliases: ROOT:health-check
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Health Check provides ping() and diagnostics() tests for the health of the network and the cluster.
+{description}
 
 
 include::{version-server}@sdk:pages:partial$health-check.adoc[tag="intro"]

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -1,4 +1,5 @@
 = Querying with N1QL
+:description: Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
 :nav-title: Querying with N1QL
 :page-topic-type: concept
 :page-aliases: ROOT:n1ql-query,
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
+{description}
 
 include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
 

--- a/modules/concept-docs/pages/nonjson.adoc
+++ b/modules/concept-docs/pages/nonjson.adoc
@@ -1,4 +1,5 @@
 = Non-JSON Documents
+:description: Binary formats & Transcoders
 :nav-title: Non-JSON
 :page-aliases: ROOT:nonjson
 :page-topic-type: concept
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Binary formats & Transcoders
+{description}
 
 include::{version-server}@sdk:shared:partial$nonjson.adoc[tag=intro]
 

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -1,4 +1,5 @@
 = Extended Attributes
+:description: Extended Attributes (XATTR) are metadata that can be provided on a per-application basis.
 :nav-title: XATTR
 :page-topic-type: concept
 :page-aliases: sdk-xattr-overview,ROOT:sdk-xattr-overview
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Extended Attributes (XATTR) are metadata that can be provided on a per-application basis.
+{description}
 
 include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -1,4 +1,5 @@
 = Install and Start Using the Scala SDK with Couchbase Server
+:description: The Couchbase Scala SDK enables you to interact with a Couchbase Server cluster from the Scala language.
 :navtitle: Start Using the SDK
 :page-topic-type: howto
 :page-aliases: ROOT:getting-started,ROOT:start-using,ROOT:hello-couchbase,ROOT:start-using-sdk
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The Couchbase Scala SDK enables you to interact with a Couchbase Server cluster from the Scala language.
+{description}
 
 == Installing the SDK
 

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -1,4 +1,5 @@
 = Analytics using the Scala SDK
+:description: Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
 :page-topic-type: howto
 :page-edition: Enterprise Edition:
 :lang: Scala
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
+{description}
 
 
 For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operations, Couchbase Data Platform offers the xref:{version-server}@server:analytics:introduction.adoc[Couchbase Analytics Service (CBAS)].

--- a/modules/howtos/pages/collecting-information-and-logging.adoc
+++ b/modules/howtos/pages/collecting-information-and-logging.adoc
@@ -1,9 +1,10 @@
 = Collecting Information & Logging
+:description: The Scala SDK logs events and also provides an event bus that transmits information about the behavior of your database system, including system and metric events.
 :nav-title: Logging
 :page-topic-type: howto
 
 [abstract]
-The Scala SDK logs events and also provides an event bus that transmits information about the behavior of your database system, including system and metric events.
+{description}
 It has no hard dependency on a specific logger implementation, but you should add one you are comfortable with.
 
 == Configuring Logging

--- a/modules/howtos/pages/concurrent-async-apis.adoc
+++ b/modules/howtos/pages/concurrent-async-apis.adoc
@@ -1,4 +1,5 @@
 = Choosing an API
+:description: The Couchbase Scala SDK allows the use, and mixing, of three distinct APIs: blocking, asynchronous, and reactive.
 :navtitle: Choosing an API
 :page-topic-type: howto
 :source-language: scala
@@ -6,7 +7,7 @@
 :page-aliases: ROOT:async-programming,multiple-apis,ROOT:batching-operations
 
 [abstract]
-The Couchbase Scala SDK allows the use, and mixing, of three distinct APIs: blocking, asynchronous, and reactive.
+{description}
 
 The Scala SDK provides three APIs, which can be freely mixed:
 

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -1,11 +1,12 @@
 = Distributed Transactions from the Scala SDK
+:description: Distributed ACID Transactions in Couchbase SDKs
 :navtitle: ACID Transactions
 :page-topic-type: howto
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Distributed ACID Transactions in Couchbase SDKs
+{description}
 
 
 Distributed ACID Transactions are not currently available for the Scala SDK.

--- a/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
+++ b/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
@@ -1,8 +1,9 @@
 = Durability in Action
+:description: Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
 :page-topic-type: howto
 
 [abstract]
-Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
+{description}
 This example case covers timeouts, node failures, and how to deal with both Couchbase Server's Synchronous Replication, and the older Server versions' Enhanced Durability.
 
 

--- a/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
+++ b/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
@@ -1,9 +1,9 @@
 = Durability in Action
-:description: Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
+:description: Handling data durability with Couchbase Server.
 :page-topic-type: howto
 
 [abstract]
-{description}
+Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
 This example case covers timeouts, node failures, and how to deal with both Couchbase Server's Synchronous Replication, and the older Server versions' Enhanced Durability.
 
 

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -1,11 +1,12 @@
 = Field Level Encryption from the SDK
+:description: The Field Level Encryption library enables encryption and decryption of JSON fields, to support FIPS-140-2 compliance.
 :page-topic-type: howto
 :page-edition: Enterprise Edition
 :page-status: Developer Preview
 // // :page-aliases: ROOT:encrypting-using-sdk.adoc
 
 [abstract]
-The Field Level Encryption library enables encryption and decryption of JSON fields, to support FIPS-140-2 compliance.
+{description}
 
 
 Client-side implementation of Field Level Encryption has not historically been a feature of the Couchbase Scala SDK,

--- a/modules/howtos/pages/error-handling.adoc
+++ b/modules/howtos/pages/error-handling.adoc
@@ -1,11 +1,12 @@
 = Handling Errors
+:description: Errors are inevitable.
 :navtitle: Handling Errors
 :page-topic-type: howto
 :page-aliases: handling-error-conditions.adoc
 :source-language: scala
 :lang: Scala
 
-Errors are inevitable.
+{description}
 The developer’s job is to be prepared for whatever is likely to come up -- and to try and be prepared for anything that conceivably could come up.
 Couchbase gives you a lot of flexibility, but it is recommended that you equip yourself with an understanding of the possibilities.
 

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,11 +1,12 @@
 = Full Text Search (FTS)
+:description: You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
 :navtitle: Searching from the SDK
 :page-topic-type: howto
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
+{description}
 
 Full Text Search or FTS allows you to create, manage, and query full text indexes on JSON documents stored in Couchbase buckets.
 It uses natural language processing for querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.

--- a/modules/howtos/pages/health-check.adoc
+++ b/modules/howtos/pages/health-check.adoc
@@ -1,9 +1,10 @@
 = Diagnosing and preventing Network Problems with Health Check
+:description: In today's distributed and virtual environments, users will often not have full administrative control over their whole network.
 :navtitle: Health Check
 :page-topic-type: howto
 
 [abstract]
-In today's distributed and virtual environments, users will often not have full administrative control over their whole network. 
+{description}
 Health Check introduces _Ping_ to check nodes are still healthy, and to force idle connections to be kept alive in environments with eager shutdowns of unused resources.
 _Diagnostics_ requests a report from a node, giving instant health check information.
 

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -1,10 +1,11 @@
 = Choosing & Using a JSON Library
+:description: The Scala SDK supports multiple options for working with JSON.
 :navtitle: JSON Libraries
 :page-topic-type: howto
 :lang: Scala
 
 [abstract]
-The Scala SDK supports multiple options for working with JSON.
+{description}
 
 == Philosophy
 The Couchbase Server is a key-value store that's agnostic to what's stored, but it's very common to store JSON.

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -1,10 +1,11 @@
 = Key Value Operations
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: KV Operations
 :page-topic-type: howto
 :page-aliases: document-operations.adoc
 :lang: Scala
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 At its heart Couchbase Server is a high-performance key-value store, and the key-value interface outlined below is the fastest and best method to perform operations involving single documents.
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -1,4 +1,5 @@
 = Managing Connections using the Scala SDK with Couchbase Server
+:description: This section describes how to connect the Scala SDK to a Couchbase cluster.
 :navtitle: Managing Connections
 :page-topic-type: concept
 :page-aliases: ROOT:managing-connections,howtos:multi-network,ROOT:connecting,ROOT:connection-advanced
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-This section describes how to connect the Scala SDK to a Couchbase cluster.
+{description}
 It contains best practices as well as information on TLS/SSL and other advanced connection options.
 
 == Connecting to a Cluster

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -1,4 +1,5 @@
 = N1QL Queries from the SDK
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: N1QL from the SDK
 :page-topic-type: howto
 :page-aliases: n1ql-query
@@ -6,7 +7,7 @@
 :example-source: howtos:example$Queries.scala
 :example-source-lang: scala
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 include::howtos:partial$n1ql-intro.adoc[]
 include::howtos:partial$n1ql-getting-started.adoc[]

--- a/modules/howtos/pages/observability-metrics.adoc
+++ b/modules/howtos/pages/observability-metrics.adoc
@@ -1,8 +1,9 @@
 = Observability Metrics Reporting
+:description: Individual request tracing presents a very specific (though isolated) view of the system.
 :page-status: Developer Preview
 :page-topic-type: howto
 
-Individual request tracing presents a very specific (though isolated) view of the system.
+{description}
 In addition, it also makes sense to capture information that aggregates request data (i.e. requests per second),
 but also data which is not tied to a specific request at all (i.e. resource utilization).
 

--- a/modules/howtos/pages/observability-tracing.adoc
+++ b/modules/howtos/pages/observability-tracing.adoc
@@ -1,8 +1,9 @@
 = Request Tracing
+:description: Collecting information about an individual request and its response is an essential feature of every observability stack.
 :page-status: Developer Preview
 :page-topic-type: howto
 
-Collecting information about an individual request and its response is an essential feature of every observability stack. 
+{description}
 
 To give insight into a request/response flow, the SDK provides a `RequestTracer` interface and ships with both a default implementation as well as modules that can feed the traces to external systems (including OpenTelemetry).
 

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -1,11 +1,12 @@
 = Provisioning Cluster Resources
+:description: Provisioning cluster resources is managed at the collection or bucket level, depending upon the service affected.
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:managing-clusters
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Provisioning cluster resources is managed at the collection or bucket level, depending upon the service affected.
+{description}
 Common use cases are outlined here, less common use cases are covered in the https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.0.4/com/couchbase/client/scala/index.html[API docs].
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -1,4 +1,5 @@
 = Authenticating against Couchbase Server
+:description: As well as Role-Based Access Control (RBAC), Couchbase offers connection with Certificate Authentication, and works transparently with LDAP.
 :page-topic-type: howto
 :page-edition: Enterprise Edition
 :page-aliases: ROOT:sdk-authentication-overview
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-As well as Role-Based Access Control (RBAC), Couchbase offers connection with Certificate Authentication, and works transparently with LDAP.
+{description}
 
 
 Our xref:hello-world:start-using-sdk.adoc[Getting Started] guide covered the basics for authorizing against a Couchbase cluster, but you may need to use alternative authentication methods such as Certification.

--- a/modules/howtos/pages/sdk-user-management-example.adoc
+++ b/modules/howtos/pages/sdk-user-management-example.adoc
@@ -1,9 +1,10 @@
 = User Management
+:description: pass:q[The Java SDK lets you create _users_, assign them _roles_ and associated _privileges_, and remove them from the system.]
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:sdk-user-management-example.adoc
 
 [abstract]
-The Java SDK lets you create _users_, assign them _roles_ and associated _privileges_, and remove them from the system.
+{description}
 
 == User-Management APIs
 

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -1,9 +1,10 @@
 = Slow Operations Logging
+:description: Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
 :page-topic-type: howto
 // :page-aliases: ROOT:
 
 [abstract]
-Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
+{description}
 Change the settings to alter how much information you collect
 
 To improve debuggability certain metrics are automatically measured and logged.

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -1,4 +1,5 @@
 = Sub-Document Operations with the Scala SDK
+:description: Sub-Document operations can be used to efficiently access and change parts of documents.
 :navtitle: Sub-Doc Operations
 :page-topic-type: howto
 :lang: Scala
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Sub-Document operations can be used to efficiently access and change parts of documents.
+{description}
 
 Sub-Document operations may be quicker and more network-efficient than _full-document_ operations such as _upsert_, _replace_ and _get_ because they only transmit the accessed sections of the document over the network.
 

--- a/modules/howtos/pages/synchronous-replication.adoc
+++ b/modules/howtos/pages/synchronous-replication.adoc
@@ -1,9 +1,10 @@
 = Synchronous Replication
+:description: Durability
 :navtitle: Synchronous Replication
 :page-topic-type: howto
 
 [abstract]
-Durability 
+{description}
 
 From Couchbase Data Platform 6.5, 
 

--- a/modules/howtos/pages/tracing-from-the-sdk.adoc
+++ b/modules/howtos/pages/tracing-from-the-sdk.adoc
@@ -1,9 +1,10 @@
 = Tracing from the .NET SDK
+:description: Threshold logging
 :navtitle: Tracing from the SDK
 :page-topic-type: howto
 
 [abstract]
-Threshold logging
+{description}
 
 // https://issues.couchbase.com/browse/DOC-4791 - 
 

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -1,9 +1,10 @@
 = Transcoders & Non-JSON Documents
+:description: The Scala SDK supports common JSON document requirements out-of-the-box.
 :nav-title: Using Transcoders
 :page-topic-type: howtos
 
 [abstract]
-The Scala SDK supports common JSON document requirements out-of-the-box.
+{description}
 Custom transcoders and serializers provide support for applications needing to perform advanced operations, including supporting non-JSON data.
 
 The Scala SDK uses the concepts of transcoders and serializers, which are used whenever data is sent to or retrieved from Couchbase Server.

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -1,4 +1,5 @@
 = MapReduce Views Using the Scala with Couchbase Server
+:description: You can use MapReduce views to create queryable indexes in Couchbase Data Platform.
 :navtitle: MapReduce Views
 :page-topic-type: howto
 :page-aliases: ROOT:view-queries-with-sdk
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-You can use MapReduce views to create queryable indexes in Couchbase Data Platform.
+{description}
 
 include::{version-server}@sdk:shared:partial$views.adoc[tag=deprecate]
 

--- a/modules/project-docs/pages/3.0-pre-release-notes.adoc
+++ b/modules/project-docs/pages/3.0-pre-release-notes.adoc
@@ -1,10 +1,11 @@
 = Pre-release Archive Release Notes
+:description: Release notes for the 3.0 Alpha & Beta Releases
 :navtitle: α & β Release Notes
 :page-topic-type: project-doc
 :page-aliases: 3.0αλφα-sdk-release-notes
 
 [abstract] 
-Release notes for the 3.0 Alpha & Beta Releases
+{description}
 
 In the run-up to the SDK 3.0 AP releases, several αλφα and βετα releases were made.
 Their release notes are maintained here for archive purposes.

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -1,12 +1,13 @@
 = Compatibility of Couchbase Features, Couchbase Server Versions, and the Couchbase Scala SDK
+:description: Features available in different SDK versions, and compatibility between Server and SDK. \
+Plus notes on Cloud, networks, and AWS Lambda.
 :navtitle: Compatibility
 :page-aliases: ROOT:overview,ROOT:compatibility-versions-features,compatibility-versions-features
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Features available in different SDK versions, and compatibility between Server and SDK.
-Plus notes on Cloud, networks, and AWS Lambda.
+{description}
 
 
 The Couchbase Scala SDK 1.1 Client supports Scala 2.12

--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -1,7 +1,8 @@
 = Get Involved
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: Get Involved
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 == Contributing
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -1,10 +1,11 @@
 = Migrating from SDK2 to SDK3 API
+:description: This is the first release of the Couchbase Scala SDK -- you will not have any code based upon older API versions.
 :nav-title: Migrating to Scala SDK 3.0 API
 :page-topic-type: concept
 :page-aliases: ROOT:migrate
 
 [abstract]
-This is the first release of the Couchbase Scala SDK -- you will not have any code based upon older API versions.
+{description}
 
 Couchbase Scala SDK 1.0 implements the Couchbase SDK 3.0 API.
 It it the first release of the Couchbase Scala SDK, there are no releases implementing older APIs.

--- a/modules/project-docs/pages/sdk-licenses.adoc
+++ b/modules/project-docs/pages/sdk-licenses.adoc
@@ -1,10 +1,11 @@
 = SDK License
+:description: Couchbase SDKs' source code is licensed under the Apache Licence 2.0. \
+Dependencies carry their own licenses.
 :page-topic-type: project-doc
 :page-aliases: ROOT:sdk-licenses.adoc
 
 [abstract]
-Couchbase SDKs' source code is licensed under the Apache Licence 2.0.
-Dependencies carry their own licenses.
+{description}
 
 The Couchbase Scala Client is distributed as source under the https://www.apache.org/licenses/LICENSE-2.0[Apache License, Version 2.0].
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1,11 +1,12 @@
 = Couchbase Scala SDK Release Notes and Archives
+:description: Release notes, installation instructions, and download archive for the Couchbase Scala Client.
 :navtitle: Release Notes
 :page-topic-type: project-doc
 :page-aliases: relnotes-scala-sdk
 
 // tag::all[]
 [abstract]
-Release notes, installation instructions, and download archive for the Couchbase Scala Client.
+{description}
 
 
 == Version 1.2.0 (20 July 2021)

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -1,4 +1,5 @@
 = Client Settings for the Scala SDK
+:description: pass:q[The `ClusterEnvironment` class enables you to configure Scala SDK options for bootstrapping, timeouts, reliability, and performance.]
 :nav-title: Client Settings
 :page-topic-type: reference
 :page-aliases: ROOT:client-settings, ROOT:env-config
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The `ClusterEnvironment` class enables you to configure Scala SDK options for bootstrapping, timeouts, reliability, and performance.
+{description}
 
 
 == The Environment Builder

--- a/modules/ref/pages/error-codes.adoc
+++ b/modules/ref/pages/error-codes.adoc
@@ -1,11 +1,12 @@
 = Errors & Exceptions Reference
+:description: The standardized error codes returned by the Couchbase Scala SDK, from cloud connection to sub-document.
 :nav-title: Error Codes
 :page-topic-type: ref
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The standardized error codes returned by the Couchbase Scala SDK, from cloud connection to sub-document.
+{description}
 
 include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=intro]
 


### PR DESCRIPTION
This PR updates all of our .adoc files to ensure we have a `:description:` attribute across our documentation pages.
This is leftover from the original ticket: https://issues.couchbase.com/browse/DOC-8463

Tracked here: https://issues.couchbase.com/browse/DOC-8952