### PR TITLE
Release 1.6.2 

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,7 +8,7 @@ nav:
 asciidoc:
   attributes:
     server_version: '7.6'
-    sdk_current_version: '1.6.2'
+    sdk_current_version: '1.6.1'
     sdk_dot_minor: '1.6'
     sdk_dot_major: '1.x'
     version-server: '7.6'

--- a/antora.yml
+++ b/antora.yml
@@ -8,7 +8,7 @@ nav:
 asciidoc:
   attributes:
     server_version: '7.6'
-    sdk_current_version: '1.6.1'
+    sdk_current_version: '1.6.2'
     sdk_dot_minor: '1.6'
     sdk_dot_major: '1.x'
     version-server: '7.6'

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -53,7 +53,7 @@ SBT::
 --
 [source,sbt]
 ----
-libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.0"
+libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.2"
 ----
 
 This will automatically use the Scala 2.12 or 2.13 builds, as appropriate for your SBT project.
@@ -67,7 +67,7 @@ It can be included in your `build.gradle` like this for 2.13:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.0'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.2'
 }
 ----
 
@@ -85,7 +85,7 @@ It can be included in your Maven `pom.xml` like this for 2.13:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.2</version>
     </dependency>
 </dependencies>
 ----

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -53,7 +53,7 @@ SBT::
 --
 [source,sbt]
 ----
-libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.2"
+libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.0"
 ----
 
 This will automatically use the Scala 2.12 or 2.13 builds, as appropriate for your SBT project.
@@ -67,7 +67,7 @@ It can be included in your `build.gradle` like this for 2.13:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.2'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.0'
 }
 ----
 
@@ -85,7 +85,7 @@ It can be included in your Maven `pom.xml` like this for 2.13:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.0</version>
     </dependency>
 </dependencies>
 ----

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -2,13 +2,15 @@
 :description: Installation instructions for the Couchbase Scala Client.
 :navtitle: Full Installation
 :page-partial:
-:page-topic-type: project-doc
+:page-toclevels: 2
 
 [abstract]
 {description}
 
 
-The Couchbase Scala SDK allows Scala applications to access a Couchbase cluster.
+This page gives full installation instructions for the {name-sdk}.
+In most cases, the xref:hello-world:start-using-sdk.adoc[Quickstart Guide] should be enough to get you up and running if you're in a hurry.
+
 
 == Prerequisites
 
@@ -21,22 +23,24 @@ The underlying OS normally makes no difference, but library incompatibilities in
 The Couchbase Scala SDK is available on the Maven repository, packaged for Scala 2.12 and 2.13.
 
 === With SBT Projects
+
 It can be included in your SBT build like this:
 
 [source,sbt]
 ----
-libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.1"
+libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.0"
 ----
 
 This will automatically use the Scala 2.12 or 2.13 builds, as appropriate for your SBT project.
 
 === With Gradle Projects
+
 It can be included in your `build.gradle` like this for 2.12:
 
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.1'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.0'
 }
 ----
 
@@ -45,7 +49,7 @@ or 2.13:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.1'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.0'
 }
 ----
 
@@ -59,7 +63,7 @@ It can be included in your Maven `pom.xml` like this for 2.12:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.12</artifactId>
-        <version>1.6.1</version>
+        <version>1.6.0</version>
     </dependency>
 </dependencies>
 ----
@@ -72,7 +76,7 @@ or 2.13:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>1.6.1</version>
+        <version>1.6.0</version>
     </dependency>
 </dependencies>
 ----

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -2,15 +2,13 @@
 :description: Installation instructions for the Couchbase Scala Client.
 :navtitle: Full Installation
 :page-partial:
-:page-toclevels: 2
+:page-topic-type: project-doc
 
 [abstract]
 {description}
 
 
-This page gives full installation instructions for the {name-sdk}.
-In most cases, the xref:hello-world:start-using-sdk.adoc[Quickstart Guide] should be enough to get you up and running if you're in a hurry.
-
+The Couchbase Scala SDK allows Scala applications to access a Couchbase cluster.
 
 == Prerequisites
 
@@ -23,24 +21,22 @@ The underlying OS normally makes no difference, but library incompatibilities in
 The Couchbase Scala SDK is available on the Maven repository, packaged for Scala 2.12 and 2.13.
 
 === With SBT Projects
-
 It can be included in your SBT build like this:
 
 [source,sbt]
 ----
-libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.0"
+libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.1"
 ----
 
 This will automatically use the Scala 2.12 or 2.13 builds, as appropriate for your SBT project.
 
 === With Gradle Projects
-
 It can be included in your `build.gradle` like this for 2.12:
 
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.0'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.1'
 }
 ----
 
@@ -49,7 +45,7 @@ or 2.13:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.0'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.1'
 }
 ----
 
@@ -63,7 +59,7 @@ It can be included in your Maven `pom.xml` like this for 2.12:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.12</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
     </dependency>
 </dependencies>
 ----
@@ -76,7 +72,7 @@ or 2.13:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
     </dependency>
 </dependencies>
 ----

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -28,7 +28,7 @@ It can be included in your SBT build like this:
 
 [source,sbt]
 ----
-libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.0"
+libraryDependencies += "com.couchbase.client" %% "scala-client" % "1.6.2"
 ----
 
 This will automatically use the Scala 2.12 or 2.13 builds, as appropriate for your SBT project.
@@ -40,7 +40,7 @@ It can be included in your `build.gradle` like this for 2.12:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.0'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.12', version: '1.6.2'
 }
 ----
 
@@ -49,7 +49,7 @@ or 2.13:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.0'
+    compile group: 'com.couchbase.client', name: 'scala-client_2.13', version: '1.6.2'
 }
 ----
 
@@ -63,7 +63,7 @@ It can be included in your Maven `pom.xml` like this for 2.12:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.12</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.2</version>
     </dependency>
 </dependencies>
 ----
@@ -76,7 +76,7 @@ or 2.13:
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.2</version>
     </dependency>
 </dependencies>
 ----

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -24,6 +24,30 @@ grep '<reactor.version>' $src/pom.xml
 grep ' <reactive-streams.version>' $src/pom.xml
 ////
 
+=== Version 1.6.2 (29 April 2024)
+
+Version 1.6.2 is the second  service release of the 1.6 series.
+
+
+https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.2/com/couchbase/client/scala/index.html[API Reference] |
+http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.2/[Core API Reference]
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.3**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+==== Improvements
+* https://issues.couchbase.com/browse/SCBC-450[SCBC-450],https://issues.couchbase.com/browse/JVMCBC-1508[JVMCBC-1508],https://issues.couchbase.com/browse/JVMCBC-1509[JVMCBC-1509]
+Upgrade dependencies.
+
+==== Bugfixes
+* https://issues.couchbase.com/browse/JVMCBC-1506[JVMCBC-1506]
+Reduced the rate at which messages appear in the server's `http_access.log` when valid credentials are provided, but the user does not have permission to access the bucket.
+
+* https://issues.couchbase.com/browse/JVMCBC-1512[JVMCBC-1512]
+Update Service in Cluster Configuration if only port is changed.
+
 === Version 1.6.1 (5 April 2024)
 
 This is a regular maintenance release.

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -24,34 +24,9 @@ grep '<reactor.version>' $src/pom.xml
 grep ' <reactive-streams.version>' $src/pom.xml
 ////
 
-=== Version 1.6.2 (29 April 2024)
+=== Version 1.6.1 (5 April 2024)
 
-Version 1.6.2 is the second  service release of the 1.6 series.
-
-
-https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.2/com/couchbase/client/scala/index.html[API Reference] |
-http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.2/[Core API Reference]
-
-The supported and tested dependencies for this release are:
-
-* io.projectreactor:**reactor-core:3.6.3**
-* org.reactivestreams:**reactive-streams:1.0.4**
-
-==== Improvements
-* https://issues.couchbase.com/browse/SCBC-450[SCBC-450],https://issues.couchbase.com/browse/JVMCBC-1508[JVMCBC-1508],https://issues.couchbase.com/browse/JVMCBC-1509[JVMCBC-1509]
-Upgrade dependencies.
-
-==== Bugfixes
-* https://issues.couchbase.com/browse/JVMCBC-1506[JVMCBC-1506]
-Reduced the rate at which messages appear in the server's `http_access.log` when valid credentials are provided, but the user does not have permission to access the bucket.
-
-* https://issues.couchbase.com/browse/JVMCBC-1512[JVMCBC-1512]
-Update Service in Cluster Configuration if only port is changed.
-
-=== Version 1.6.1 (2 April 2024)
-
-Version 1.6.1 is the first service release of the 1.6 series.
-
+This is a regular maintenance release.
 
 https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.1/com/couchbase/client/scala/index.html[API Reference] |
 http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.1/[Core API Reference]
@@ -62,12 +37,14 @@ The supported and tested dependencies for this release are:
 * org.reactivestreams:**reactive-streams:1.0.4**
 
 ==== Improvements
+
 * https://issues.couchbase.com/browse/JVMCBC-1477[JVMCBC-1477]
-Reduced the rate at which messages appear in the server's `http_access.log` when invalid credentials are provided.
+Reduced the rate at which messages appear in the server's `http_access.log` when invalid credentials are provided resulting in 401 errors. 
+Issues resulting in 403 errors will be handled in a future release.
 * https://issues.couchbase.com/browse/JVMCBC-1498[JVMCBC-1498]
 The fields of a `SearchRow` from a Full-Text Search result are now included in the output of `SearchRow.toString()`.
 * https://issues.couchbase.com/browse/JVMCBC-1499[JVMCBC-1499]
-DNS SRV caching is now disabled. The SDK now responds quicker to DNS changes in dynamic environments like Kubernetes.
+Disabled DNS SRV caching. The SDK now responds quicker to DNS changes in dynamic environments like Kubernetes.
 * https://issues.couchbase.com/browse/JVMCBC-1500[JVMCBC-1500]
 Added `EventingFunctionLanguageCompatibility.VERSION_7_2_0`.
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -24,9 +24,34 @@ grep '<reactor.version>' $src/pom.xml
 grep ' <reactive-streams.version>' $src/pom.xml
 ////
 
-=== Version 1.6.1 (5 April 2024)
+=== Version 1.6.2 (29 April 2024)
 
-This is a regular maintenance release.
+Version 1.6.2 is the second  service release of the 1.6 series.
+
+
+https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.2/com/couchbase/client/scala/index.html[API Reference] |
+http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.2/[Core API Reference]
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.3**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+==== Improvements
+* https://issues.couchbase.com/browse/SCBC-450[SCBC-450],https://issues.couchbase.com/browse/JVMCBC-1508[JVMCBC-1508],https://issues.couchbase.com/browse/JVMCBC-1509[JVMCBC-1509]
+Upgrade dependencies.
+
+==== Bugfixes
+* https://issues.couchbase.com/browse/JVMCBC-1506[JVMCBC-1506]
+Reduced the rate at which messages appear in the server's `http_access.log` when valid credentials are provided, but the user does not have permission to access the bucket.
+
+* https://issues.couchbase.com/browse/JVMCBC-1512[JVMCBC-1512]
+Update Service in Cluster Configuration if only port is changed.
+
+=== Version 1.6.1 (2 April 2024)
+
+Version 1.6.1 is the first service release of the 1.6 series.
+
 
 https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.1/com/couchbase/client/scala/index.html[API Reference] |
 http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.1/[Core API Reference]
@@ -37,14 +62,12 @@ The supported and tested dependencies for this release are:
 * org.reactivestreams:**reactive-streams:1.0.4**
 
 ==== Improvements
-
 * https://issues.couchbase.com/browse/JVMCBC-1477[JVMCBC-1477]
-Reduced the rate at which messages appear in the server's `http_access.log` when invalid credentials are provided resulting in 401 errors. 
-Issues resulting in 403 errors will be handled in a future release.
+Reduced the rate at which messages appear in the server's `http_access.log` when invalid credentials are provided.
 * https://issues.couchbase.com/browse/JVMCBC-1498[JVMCBC-1498]
 The fields of a `SearchRow` from a Full-Text Search result are now included in the output of `SearchRow.toString()`.
 * https://issues.couchbase.com/browse/JVMCBC-1499[JVMCBC-1499]
-Disabled DNS SRV caching. The SDK now responds quicker to DNS changes in dynamic environments like Kubernetes.
+DNS SRV caching is now disabled. The SDK now responds quicker to DNS changes in dynamic environments like Kubernetes.
 * https://issues.couchbase.com/browse/JVMCBC-1500[JVMCBC-1500]
 Added `EventingFunctionLanguageCompatibility.VERSION_7_2_0`.
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -26,8 +26,7 @@ grep ' <reactive-streams.version>' $src/pom.xml
 
 === Version 1.6.2 (29 April 2024)
 
-Version 1.6.2 is the second  service release of the 1.6 series.
-
+This is a regular maintenance release.
 
 https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.2/com/couchbase/client/scala/index.html[API Reference] |
 http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.2/[Core API Reference]
@@ -38,15 +37,17 @@ The supported and tested dependencies for this release are:
 * org.reactivestreams:**reactive-streams:1.0.4**
 
 ==== Improvements
-* https://issues.couchbase.com/browse/SCBC-450[SCBC-450],https://issues.couchbase.com/browse/JVMCBC-1508[JVMCBC-1508],https://issues.couchbase.com/browse/JVMCBC-1509[JVMCBC-1509]
-Upgrade dependencies.
+
+* https://issues.couchbase.com/browse/SCBC-450[SCBC-450], https://issues.couchbase.com/browse/JVMCBC-1508[JVMCBC-1508] and https://issues.couchbase.com/browse/JVMCBC-1509[JVMCBC-1509]
+Upgraded dependencies.
 
 ==== Bugfixes
-* https://issues.couchbase.com/browse/JVMCBC-1506[JVMCBC-1506]
-Reduced the rate at which messages appear in the server's `http_access.log` when valid credentials are provided, but the user does not have permission to access the bucket.
 
+* https://issues.couchbase.com/browse/JVMCBC-1506[JVMCBC-1506]
+Reduced the rate at which messages appear in the server's `http_access.log` when a user provides valid credentials but does not have permission to access the bucket.
 * https://issues.couchbase.com/browse/JVMCBC-1512[JVMCBC-1512]
-Update Service in Cluster Configuration if only port is changed.
+Updated Service in Cluster Configuration if only the port is changed.
+
 
 === Version 1.6.1 (5 April 2024)
 


### PR DESCRIPTION
I'm not sure why some of the versions are going from 1.6.0 -> 1.62 (instead of 1.6.1 -> 1.6.2).  I see my pull review for 1.6.1 is still there. Maybe that has something to do with it (?). 