### PR TITLE
[AV-82442] Update Scala release 1.3 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -40,7 +40,7 @@ include::example$StartUsing.scala[tags=**]
 --
 ====
 
-The Couchbase Capella free trial version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 == Quick Install
 


### PR DESCRIPTION
Removed mentions of trial in the Scala SDK docs. Only locations found were the start-using-sdk.adoc page.