### PR TITLE
[AV-82442] Update Scala release 1.4 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -40,7 +40,7 @@ include::example$StartUsing.scala[tags=**]
 --
 ====
 
-The Couchbase Capella free trial version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 == Quick Install
 
@@ -106,7 +106,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically by the Capella free trial.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -106,7 +106,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.


### PR DESCRIPTION
Removed mentions of trial in the Scala SDK docs. Only locations found were the start-using-sdk.adoc page.