### PR TITLE
[AV-82442] Update Scala release 1.7 docs for Free Tier. 

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -53,7 +53,7 @@ there are several self-managed options available:
 Couchbase Capella::
 +
 --
-If you haven't already got a database set up, the easiest route is to https://cloud.couchbase.com/sign-up[sign up to a trial of Couchbase Capella^], 
+If you haven't already got a database set up, the easiest route is to https://cloud.couchbase.com/sign-up[sign up to Couchbase Capella and deploy a perpetual free tier cluster^], 
 then come back to this page.
 Make a note of the xref:cloud:get-started:connect.adoc[endpoint] to connect to, 
 and remember the credentials for the user that you set up.
@@ -98,7 +98,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically by the Capella free trial.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -53,7 +53,7 @@ there are several self-managed options available:
 Couchbase Capella::
 +
 --
-If you haven't already got a database set up, the easiest route is to https://cloud.couchbase.com/sign-up[sign up to Couchbase Capella and deploy a perpetual free tier cluster^], 
+If you haven't already got a database set up, the easiest route is to https://cloud.couchbase.com/sign-up[sign up to Couchbase Capella and deploy a free tier cluster^], 
 then come back to this page.
 Make a note of the xref:cloud:get-started:connect.adoc[endpoint] to connect to, 
 and remember the credentials for the user that you set up.
@@ -98,7 +98,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/student-record-developer-tutorial.adoc
+++ b/modules/hello-world/pages/student-record-developer-tutorial.adoc
@@ -196,7 +196,7 @@ without the need for complex table joins to retrieve the enrollment information.
 
 == Creating Your Database
 
-In the next part of the tutorial, you're going to begin your exploration of Couchbase by signing up to Capella and deploying a perpetual free tier cluster.
+In the next part of the tutorial, you're going to begin your exploration of Couchbase by signing up to Capella and deploying a free tier cluster.
 Capella is the simplest way of using Couchbase;
 should you wish to try a local Docker installation instead, you can adjust the connection steps in the tutorial below --
 but we strongly recommend Capella as the easiest way of getting started.
@@ -207,7 +207,7 @@ all that you need to follow along with this tutorial.
 
 === Capella Installation
 
-Sign up to of https://www.couchbase.com/products/capella[the Couchbase Capella cloud service] and deploy a perpetual free tier cluster to properly run through the tutorials for xref:cloud:get-started:get-started.adoc[Getting Started with Couchbase Capella].
+Sign up to of https://www.couchbase.com/products/capella[the Couchbase Capella cloud service] and deploy a free tier cluster to properly run through the tutorials for xref:cloud:get-started:get-started.adoc[Getting Started with Couchbase Capella].
 
 Make a note of the database endpoint, and any user names and passwords that you set up.
 You will use these to access your Capella database from the {name-sdk}.

--- a/modules/hello-world/pages/student-record-developer-tutorial.adoc
+++ b/modules/hello-world/pages/student-record-developer-tutorial.adoc
@@ -196,18 +196,18 @@ without the need for complex table joins to retrieve the enrollment information.
 
 == Creating Your Database
 
-In the next part of the tutorial, you're going to begin your exploration of Couchbase by by signing up for a Capella trial.
+In the next part of the tutorial, you're going to begin your exploration of Couchbase by signing up to Capella and deploying a perpetual free tier cluster.
 Capella is the simplest way of using Couchbase;
 should you wish to try a local Docker installation instead, you can adjust the connection steps in the tutorial below --
 but we strongly recommend Capella as the easiest way of getting started.
 
-On a free trial you will get a cluster of three nodes, featuring the Data Service, Query Service, and Index Service --
+In free tier, you'll get a free cluster of three nodes, featuring the Data Service, Query Service, and Index Service --
 all that you need to follow along with this tutorial.
 
 
 === Capella Installation
 
-Sign up to a free trial of https://www.couchbase.com/products/capella[the Couchbase Capella cloud service] then you can run through the tutorials for xref:cloud:get-started:get-started.adoc[Getting Started with Couchbase Capella].
+Sign up to of https://www.couchbase.com/products/capella[the Couchbase Capella cloud service] and deploy a perpetual free tier cluster to properly run through the tutorials for xref:cloud:get-started:get-started.adoc[Getting Started with Couchbase Capella].
 
 Make a note of the database endpoint, and any user names and passwords that you set up.
 You will use these to access your Capella database from the {name-sdk}.


### PR DESCRIPTION
Removed mentions of trial in the Scala SDK docs. Only locations found were the start-using-sdk.adoc page and the student-record-developer-tutorial.adoc. 