### PR TITLE
Update snapshot repository info

### DIFF
--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -88,7 +88,7 @@ or 2.13:
 [snapshots]
 == Using a Snapshot Version
 
-Couchbase publishes pre-release snapshot artifacts to the Sonatype OSS Snapshot Repository.
+Couchbase publishes pre-release snapshot artifacts to the Central Portal Snapshots Repository.
 If you wish to use a snapshot version, you'll need to tell your build tool about this repository.
 
 [{tabs}]
@@ -100,12 +100,17 @@ Maven::
 [source,xml]
 ----
 <repositories>
-  <repository>
-    <id>sonatype-snapshots</id>
-    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    <releases><enabled>false</enabled></releases>
-    <snapshots><enabled>true</enabled></snapshots>
-  </repository>
+    <repository>
+        <name>Central Portal Snapshots</name>
+        <id>central-portal-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
 </repositories>
 ----
 --
@@ -118,7 +123,7 @@ Gradle (Groovy)::
 repositories {
     mavenCentral()
     maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://central.sonatype.com/repository/maven-snapshots/"
         mavenContent { snapshotsOnly() }
     }
 }


### PR DESCRIPTION
Motivation
----------
Now that we've migrated from OSSRH to Central Portal, snapshots are in a different location.