### PR TITLE
Release notes for 3.11.1

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
   attributes:
     page-nav-header-levels: 2
     server_version: '8.0.0'
-    sdk_current_version: '3.11.0'
+    sdk_current_version: '3.11.1'
     sdk_dot_minor: '3.11'
     sdk_dot_major: '3.x'
     version-server: '8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,10 @@ sourceSets {
 }
 
 dependencies {
-    implementation group: 'com.couchbase.client', name: 'scala-client_2.12', version: '3.11.0'
-    implementation group: 'com.couchbase.client', name: 'tracing-opentelemetry', version: '3.11.0'
-    implementation group: 'com.couchbase.client', name: 'metrics-opentelemetry', version: '3.11.0'
-    implementation group: 'com.couchbase.client', name: 'metrics-micrometer', version: '3.11.0'
+    implementation group: 'com.couchbase.client', name: 'scala-client_2.12', version: '3.11.1'
+    implementation group: 'com.couchbase.client', name: 'tracing-opentelemetry', version: '3.11.1'
+    implementation group: 'com.couchbase.client', name: 'metrics-opentelemetry', version: '3.11.1'
+    implementation group: 'com.couchbase.client', name: 'metrics-micrometer', version: '3.11.1'
 
     implementation "org.scalatest:scalatest_2.12:3.1.1"
 

--- a/modules/devguide/examples/scala/pom.xml
+++ b/modules/devguide/examples/scala/pom.xml
@@ -2,6 +2,6 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>scala-client_2.13</artifactId>
-        <version>3.11.0</version>
+        <version>3.11.1</version>
     </dependency>
 </dependencies>

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -40,6 +40,7 @@ All other functionality works unchanged and users can upgrade existing applicati
 The major new feature starting in the 3.9 series is the addition of a new version of the SDK, built for Scala 3.
 The Scala 3 version of the SDK has some API differences, documented on xref:project-docs:migrating-to-scala-3.adoc[migrating to Scala 3].
 But we expect the majority of Scala 2 applications will be able to migrate to Scala 3 and the Scala 3 version of the SDK with no-to-minimal differences.
+Note that the API reference links below are for the Scala 2.12 version of the SDK.
 
 We always recommend using the latest version of the SDK -- it contains all of the latest security patches and support for new and upcoming features.
 All patch releases for each dot minor release should be API compatible, and safe to upgrade;
@@ -56,17 +57,33 @@ grep ' <reactive-streams.version>' $src/pom.xml
 
 
 
+=== Version 3.11.1 (16 February 2026)
+
+https://docs.couchbase.com/sdk-api/couchbase-scala-client-3.11.1/com/couchbase/client/scala/index.html[API Reference] |
+https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.1/[Core API Reference]
+
+This critical release fixes a regression in `3.11.0` that caused documents inserted in transactions to expire immediately.
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.9**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+==== Bug Fixes
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1712[JVMCBC-1712]:
+Document inserted in transactions no longer expire immediately.
+This fixes a regression in `3.11.0`.
+
+
 === Version 3.11.0 (04 February 2026)
 
 https://docs.couchbase.com/sdk-api/couchbase-scala-client-3.11.0/com/couchbase/client/scala/index.html[API Reference] |
 https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.0/[Core API Reference]
 
 [CAUTION]
-This version has a serious bug that causes a document inserted in a transaction to expire immediately.
-If your project uses transactions, we recommend staying on 3.10.1 until 3.11.1 is available.
-
-Note that the API reference is for the Scala 2.12 version of the SDK.
-The Scala 3 version of the SDK has some API differences, documented on xref:project-docs:migrating-to-scala-3.adoc[migrating to Scala 3].
+This version has https://jira.issues.couchbase.com/browse/JVMCBC-1712[a serious bug that causes documents inserted in transactions to expire immediately].
+We recommend upgrading directly to `3.11.1`.
 
 The supported and tested dependencies for this release are:
 


### PR DESCRIPTION
Incidentally, moved the note about the API reference docs being for Scala 2.12 (instead of Scala 3) to the top-level info section, since it doesn't apply to a particular SDK version, and we probably don't want to repeat it as boilerplate in every version's release notes.